### PR TITLE
Adopt Feather icons and refresh portfolio visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# WM-website
+# Walker Media Website
+
+A marketing site for Walker Media that highlights custom branding, development, SEO, and AI implementation services with conversion-focused, search-optimized copy.
+
+## Pages
+- **Home:** Gradient hero with SEO-led messaging, featured work showcase (Vibrant Living at Home, Radix Law, Telecom Advisors Group), and collaboration details.
+- **About:** Studio story, principles, and outcomes with timeline and partnership highlights written to emphasize expertise.
+- **Web & Product:** Detailed breakdown of Walker Media’s research, UX, design, development, and optimization services plus featured case studies.
+- **AI Services:** Workflow audits, agent design, content automation, and strategy consulting packaged with pricing and process details.
+- **Contact:** High-impact hero, project-fit details, and a modern inquiry form.
+
+## Experience
+- Responsive layout with bright gradients, glass cards, Feather-powered iconography, and a mobile-ready navigation anchored by the Walker Media logo.
+- Scroll-triggered reveals and elevated button transitions driven by a lightweight Intersection Observer script.
+- SEO-conscious storytelling across every page showcasing Walker Media’s experience, results, and AI-driven differentiators.
+- Case study illustrations are bundled locally to ensure consistent visuals across the portfolio grid.
+
+## Getting Started
+Open `index.html` in your browser to explore the site locally. All styling is contained in `assets/css/style.css`.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About Walker Media | Web Design, SEO & AI Expertise</title>
+  <meta name="description" content="Meet Walker Media’s founder-led studio delivering custom branding, high-performance web design, SEO strategy, and AI automation backed by 15+ years of experience.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <nav class="nav">
+        <a class="brand" href="index.html">
+          <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+          <span class="brand-name">Walker Media</span>
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label" aria-hidden="true">Menu</span>
+        </button>
+        <ul class="nav-links" id="primary-navigation">
+          <li><a href="index.html">Home</a></li>
+          <li><a class="active" href="about.html">About</a></li>
+          <li><a href="services.html">Web &amp; Product</a></li>
+          <li><a href="ai-services.html">AI Services</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li class="nav-cta"><a class="btn btn-primary" href="contact.html">Book a Discovery Call</a></li>
+        </ul>
+        <a class="btn btn-ghost nav-cta-desktop" href="contact.html">Book a Discovery Call</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-inner">
+        <div class="hero-copy" data-animate>
+          <span class="eyebrow">Founder-led studio</span>
+          <h1>Senior-level brand, web, SEO, and AI leadership you can plug directly into your team.</h1>
+          <p>Hi, I’m Zac Walker—the founder of Walker Media, a designer-developer hybrid with 15+ years architecting search-optimized websites, building enterprise-ready design systems, and deploying AI automations that unlock capacity for marketing and product teams nationwide.</p>
+          <div class="badge-grid" style="margin-top:1.5rem;">
+            <span class="badge">Design systems</span>
+            <span class="badge">Full-stack development</span>
+            <span class="badge">AI automation</span>
+            <span class="badge">SEO & growth</span>
+          </div>
+        </div>
+        <div class="hero-panel" data-animate>
+          <div class="glass-card">
+            <h3>Guiding principles</h3>
+            <ul class="checklist">
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Lead with insight—customer research, analytics, and keyword data guide every design and line of code.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Design for trust—interfaces must feel refined, inclusive, fast, and intuitive on every device.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Automate momentum—AI agents and documented systems free teams to focus on the work that matters.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container split-section">
+        <div data-animate>
+          <div class="section-heading">
+            <span class="eyebrow">Trajectory</span>
+            <h2>A journey shaped by enterprise launches, startup scrappiness, and measurable results.</h2>
+            <p>From early agency roles to leading nationwide rollouts, each chapter sharpened the ability to deliver experiences that rank, convert, and automate with measurable polish.</p>
+          </div>
+          <div class="timeline">
+            <div class="timeline-item">
+              <h3>2009 — Foundations</h3>
+              <p>Designed and developed award-winning campaigns inside boutique agencies, mastering collaboration with marketing and product teams on high-stakes launches.</p>
+            </div>
+            <div class="timeline-item">
+              <h3>2014 — Scaling capabilities</h3>
+              <p>Led cross-functional teams to ship complex web applications, ecommerce storefronts, and multi-channel growth programs that blended SEO, CRO, and analytics.</p>
+            </div>
+            <div class="timeline-item">
+              <h3>2018 — Walker Media launches</h3>
+              <p>Created a studio focused on marrying high-end design with robust development, revenue dashboards, and retention-minded SEO.</p>
+            </div>
+            <div class="timeline-item">
+              <h3>2021 & beyond — AI-first future</h3>
+              <p>Embedded custom AI agents inside client operations to automate onboarding, support, and reporting workflows for marketing, success, and sales teams.</p>
+            </div>
+          </div>
+        </div>
+        <div class="split-card" data-animate>
+          <h3>Client outcomes</h3>
+          <div class="metrics-grid" style="margin-top:1.5rem;">
+            <div class="metric">
+              <strong>40%</strong>
+              Increase in qualified demos after a brand, messaging, and SEO overhaul.
+            </div>
+            <div class="metric">
+              <strong>2x</strong>
+              Faster onboarding thanks to AI-powered workflow automation and knowledge bases.
+            </div>
+          </div>
+          <p style="margin-top:1.5rem;" class="quote">“Walker Media reimagined our brand, leveled-up our SEO foundation, and automated onboarding with AI. We saw a 40% lift in qualified leads and halved admin time within 60 days.”<br><span style="color:#0038ff; font-weight:600;">— Taylor Reed, VP Marketing, Horizon Labs</span></p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container split-section">
+        <div data-animate>
+          <div class="section-heading">
+            <span class="eyebrow">Partnership</span>
+            <h2>Why teams choose Walker Media</h2>
+            <p>Balanced aesthetics, senior-level execution, and AI-infused workflows add up to engagements that feel seamless for stakeholders and measurable for leadership.</p>
+          </div>
+          <ul class="list-highlight">
+            <li><span>Integrated capabilities:</span> One partner for brand, product, SEO, and automation ensures every touchpoint is connected.</li>
+            <li><span>Operator mindset:</span> Engagements are measured by pipeline, retention, search visibility, and time saved—not just pixels shipped.</li>
+            <li><span>Long-term thinking:</span> Launches include optimization sprints, analytics reviews, training, and documentation to keep momentum compounding.</li>
+          </ul>
+        </div>
+        <div class="split-card" data-animate>
+          <h3>Let’s collaborate</h3>
+          <p>Whether you’re re-platforming a site, introducing AI to your workflows, or crafting a new brand identity, Walker Media is ready to ship world-class experiences backed by data and operational rigor.</p>
+          <a class="btn btn-primary" href="contact.html" style="margin-top:1.75rem; width:fit-content;">Start a project</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html">
+            <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+            <span class="brand-name">Walker Media</span>
+          </a>
+          <p>World-class branding, web, and AI solutions crafted with agency-level polish and the agility of a boutique partner.</p>
+        </div>
+        <div>
+          <h4>Studio</h4>
+          <p>Remote-first, partnering nationwide<br>Selective engagements focused on measurable outcomes.</p>
+        </div>
+        <div class="footer-links">
+          <h4>Explore</h4>
+          <p><a href="about.html">About</a></p>
+          <p><a href="services.html">Web &amp; Product</a></p>
+          <p><a href="ai-services.html">AI Services</a></p>
+          <p><a href="contact.html">Contact</a></p>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <small>© <span id="year"></span> Walker Media. All rights reserved.</small>
+        <div class="socials">
+          <a href="https://www.linkedin.com" aria-label="LinkedIn"><i data-feather="linkedin"></i></a>
+          <a href="mailto:zac@walkermediaco.com" aria-label="Email"><i data-feather="mail"></i></a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <script src="https://unpkg.com/feather-icons" defer></script>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/ai-services.html
+++ b/ai-services.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Services | Walker Media Automation &amp; Workflow Design</title>
+  <meta name="description" content="Partner with Walker Media for AI workflow audits, custom automation design, content automation, and implementation consulting that saves teams time and drives measurable impact.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <nav class="nav">
+        <a class="brand" href="index.html">
+          <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+          <span class="brand-name">Walker Media</span>
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label" aria-hidden="true">Menu</span>
+        </button>
+        <ul class="nav-links" id="primary-navigation">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Web &amp; Product</a></li>
+          <li><a class="active" href="ai-services.html">AI Services</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li class="nav-cta"><a class="btn btn-primary" href="contact.html">Book a Discovery Call</a></li>
+        </ul>
+        <a class="btn btn-ghost nav-cta-desktop" href="contact.html">Book a Discovery Call</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-inner">
+        <div class="hero-copy" data-animate>
+          <span class="eyebrow">AI Services</span>
+          <h1>Automate operations with AI agents, workflows, and strategy built for your business.</h1>
+          <p>Walker Media helps teams identify automation opportunities, design custom AI agents, and implement responsible systems that eliminate repetitive work while protecting your brand voice.</p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="contact.html">Book a Free AI Workflow Audit</a>
+            <div class="hero-annotation">
+              <span class="icon" aria-hidden="true"><i data-feather="cpu"></i></span>
+              <div>From audits to full deployments, we tailor AI to your tech stack and goals.</div>
+            </div>
+          </div>
+        </div>
+        <div class="hero-panel" data-animate>
+          <div class="glass-card">
+            <h3>AI impact delivered</h3>
+            <ul class="checklist">
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>120+ hours saved per quarter through automated workflows.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Consistent, on-brand content publishing across channels.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Leadership visibility through automated reporting and insights.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">AI Workflow Audits</span>
+          <h2>Identify opportunities for automation and efficiency.</h2>
+          <p>We’ll review your current processes—from marketing and sales to admin and customer service—and pinpoint where AI can make the biggest impact.</p>
+        </div>
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <ul class="list-highlight">
+              <li><span>Discover bottlenecks and repetitive tasks</span></li>
+              <li><span>Get a customized automation roadmap</span></li>
+              <li><span>See exactly how AI can save you time and money</span></li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <div class="service-callout">
+              <span class="callout-kicker"><span class="icon" aria-hidden="true"><i data-feather="grid"></i></span>Deliverable</span>
+              <p>A tailored AI workflow report with actionable steps.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">AI Workflow &amp; Agent Design</span>
+          <h2>Custom-built automations to handle the work for you.</h2>
+          <p>We create smart AI workflows and agents that act like digital team members—completing tasks, sending emails, drafting content, updating CRMs, and more.</p>
+        </div>
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <ul class="list-highlight">
+              <li><span>Automate lead follow-ups, content creation, reporting</span></li>
+              <li><span>Design AI “agents” for specific roles (writer, scheduler, researcher)</span></li>
+              <li><span>Integrate with your tools: Google Workspace, Notion, Slack, CRMs, etc.</span></li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <div class="service-callout">
+              <span class="callout-kicker"><span class="icon" aria-hidden="true"><i data-feather="layers"></i></span>Integration</span>
+              <p>We connect AI seamlessly into your existing systems and automate the handoffs.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">AI Content Automation</span>
+          <h2>Let AI handle your blogs, social posts, and emails.</h2>
+          <p>Tired of staring at a blank page? We’ll set up AI workflows that write, edit, and optimize content for your brand voice.</p>
+        </div>
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <ul class="list-highlight">
+              <li><span>Blog post generation and scheduling</span></li>
+              <li><span>SEO-optimized drafts with human oversight</span></li>
+              <li><span>Social media and email copy that’s on-brand and consistent</span></li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <div class="service-callout">
+              <span class="callout-kicker"><span class="icon" aria-hidden="true"><i data-feather="edit-3"></i></span>Collaboration</span>
+              <p>You approve every deliverable—AI does the heavy lifting so your team can focus on strategy.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">AI Strategy &amp; Implementation Consulting</span>
+          <h2>Adopt AI with confidence and clarity.</h2>
+          <p>Understand what AI can (and can’t) do for your business, develop responsible usage policies, and train your team to use it effectively.</p>
+        </div>
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <ul class="list-highlight">
+              <li><span>AI adoption roadmap</span></li>
+              <li><span>Internal team training</span></li>
+              <li><span>Ethical AI usage guidelines</span></li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <div class="service-callout">
+              <span class="callout-kicker"><span class="icon" aria-hidden="true"><i data-feather="trending-up"></i></span>Future-proofing</span>
+              <p>Keep your organization compliant, efficient, and ready for whatever comes next.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Sample Use Cases</span>
+          <h2>Here’s how businesses are already using our AI systems.</h2>
+        </div>
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <ul class="list-highlight">
+              <li><span>Automating blog and social media posting</span></li>
+              <li><span>Summarizing weekly analytics reports and emailing them to leadership</span></li>
+              <li><span>Managing lead intake, follow-ups, and scheduling</span></li>
+              <li><span>Drafting client emails and proposals</span></li>
+              <li><span>Generating meeting summaries and task lists automatically</span></li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <div class="service-callout">
+              <span class="callout-kicker"><span class="icon" aria-hidden="true"><i data-feather="message-circle"></i></span>Need something unique?</span>
+              <p>If you can describe it, we can probably automate it.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Our Process</span>
+          <h2>Proven steps to launch and sustain your AI initiatives.</h2>
+        </div>
+        <div class="timeline">
+          <div class="timeline-item" data-animate>
+            <span class="timeline-step">1</span>
+            <h3>Discovery Call</h3>
+            <p>Understand your business, goals, and current tech stack.</p>
+          </div>
+          <div class="timeline-item" data-animate>
+            <span class="timeline-step">2</span>
+            <h3>Workflow Audit</h3>
+            <p>Identify high-impact tasks and map opportunities for automation.</p>
+          </div>
+          <div class="timeline-item" data-animate>
+            <span class="timeline-step">3</span>
+            <h3>Design &amp; Build</h3>
+            <p>Create AI workflows, train agents, and integrate them with your tools.</p>
+          </div>
+          <div class="timeline-item" data-animate>
+            <span class="timeline-step">4</span>
+            <h3>Testing &amp; Training</h3>
+            <p>Validate outputs, refine prompts, and onboard your team.</p>
+          </div>
+          <div class="timeline-item" data-animate>
+            <span class="timeline-step">5</span>
+            <h3>Ongoing Optimization</h3>
+            <p>Monitor performance, roll out improvements, and expand automation.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Packages</span>
+          <h2>Engagement options tailored to your automation goals.</h2>
+        </div>
+        <div class="table-wrapper">
+          <table class="pricing-table">
+            <thead>
+              <tr>
+                <th>Package</th>
+                <th>Includes</th>
+                <th>Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>AI Workflow Audit</td>
+                <td>60-minute strategy session + automation report</td>
+                <td>$299</td>
+              </tr>
+              <tr>
+                <td>Custom AI Setup</td>
+                <td>1–2 tailored workflows or AI agents</td>
+                <td>$1,500–$3,000</td>
+              </tr>
+              <tr>
+                <td>Monthly Optimization</td>
+                <td>Continuous improvement, updates, support</td>
+                <td>$259–$499/mo</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <h3>Get Started</h3>
+            <p>Don’t let repetitive tasks slow your business down. Let’s design your AI-powered system that works for you — 24/7.</p>
+          </div>
+          <div class="split-card" data-animate>
+            <a class="btn btn-primary" href="contact.html">Schedule Your Consultation</a>
+            <p class="small-note" style="margin-top:1rem;"><span class="icon" aria-hidden="true"><i data-feather="phone"></i></span>Book a Free AI Workflow Audit today and see how much time you could save.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html">
+            <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+            <span class="brand-name">Walker Media</span>
+          </a>
+          <p>World-class branding, web, and AI solutions crafted with agency-level polish and the agility of a boutique partner.</p>
+        </div>
+        <div>
+          <h4>Studio</h4>
+          <p>Remote-first, partnering nationwide<br>Selective engagements focused on measurable outcomes.</p>
+        </div>
+        <div class="footer-links">
+          <h4>Explore</h4>
+          <p><a href="about.html">About</a></p>
+          <p><a href="services.html">Web &amp; Product</a></p>
+          <p><a href="ai-services.html">AI Services</a></p>
+          <p><a href="contact.html">Contact</a></p>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <small>© <span id="year"></span> Walker Media. All rights reserved.</small>
+        <div class="socials">
+          <a href="https://www.linkedin.com" aria-label="LinkedIn"><i data-feather="linkedin"></i></a>
+          <a href="mailto:zac@walkermediaco.com" aria-label="Email"><i data-feather="mail"></i></a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <script src="https://unpkg.com/feather-icons" defer></script>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,1147 @@
+:root {
+  --brand: #0038ff;
+  --brand-dark: #001e7b;
+  --brand-accent: #0091ff;
+  --brand-soft: rgba(0, 56, 255, 0.12);
+  --bg: #f7f9ff;
+  --bg-strong: #ffffff;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: rgba(243, 247, 255, 0.95);
+  --surface-border: rgba(15, 23, 42, 0.08);
+  --surface-border-strong: rgba(0, 56, 255, 0.22);
+  --text: #0f172a;
+  --muted: #475569;
+  --muted-strong: #1e293b;
+  --radius-xl: 32px;
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --shadow-xl: 0 40px 95px rgba(15, 23, 42, 0.18);
+  --shadow-md: 0 24px 60px rgba(15, 23, 42, 0.15);
+  --shadow-soft: 0 14px 35px rgba(15, 23, 42, 0.12);
+  --transition: all 0.25s ease;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  min-height: 100%;
+}
+
+body {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background:
+    radial-gradient(circle at 18% -10%, rgba(0, 56, 255, 0.12), transparent 55%),
+    radial-gradient(circle at 82% 0%, rgba(0, 145, 255, 0.1), transparent 42%),
+    linear-gradient(180deg, #fdfdff 0%, #f2f6ff 55%, #ffffff 100%);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+body.nav-open {
+  overflow: hidden;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+a:not(.btn):hover {
+  color: var(--brand);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.icon svg {
+  width: 1em;
+  height: 1em;
+}
+
+p {
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.75rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  backdrop-filter: blur(18px);
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--surface-border);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  position: relative;
+  padding: 1.35rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.15rem;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.brand-logo {
+  height: 48px;
+  width: auto;
+  display: block;
+}
+
+.brand-name {
+  display: inline-block;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}
+
+.menu-toggle {
+  display: none;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--surface-border);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--muted-strong);
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition);
+  z-index: 25;
+}
+
+.menu-toggle:hover {
+  border-color: rgba(0, 56, 255, 0.3);
+  color: var(--brand);
+}
+
+.menu-toggle:focus-visible {
+  outline: 3px solid rgba(0, 56, 255, 0.35);
+  outline-offset: 2px;
+}
+
+.menu-toggle[aria-expanded="true"] {
+  color: var(--brand);
+  border-color: rgba(0, 56, 255, 0.35);
+  background: rgba(0, 56, 255, 0.1);
+}
+
+.menu-icon {
+  position: relative;
+  width: 20px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+  transition: var(--transition);
+}
+
+.menu-icon::before,
+.menu-icon::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 20px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+  transition: var(--transition);
+}
+
+.menu-icon::before {
+  top: -6px;
+}
+
+.menu-icon::after {
+  top: 6px;
+}
+
+.menu-toggle[aria-expanded="true"] .menu-icon {
+  background: transparent;
+}
+
+.menu-toggle[aria-expanded="true"] .menu-icon::before {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.menu-toggle[aria-expanded="true"] .menu-icon::after {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.menu-label {
+  font-size: 0.95rem;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.nav-links a {
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.nav-links a:hover,
+.nav-links a.active {
+  color: var(--brand);
+  border-color: rgba(0, 56, 255, 0.25);
+  background: rgba(0, 56, 255, 0.08);
+}
+
+.nav-cta {
+  display: none;
+}
+
+.nav-cta .btn {
+  width: 100%;
+}
+
+.nav-cta-desktop {
+  white-space: nowrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.98rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.4s ease, background 0.4s ease, border-color 0.4s ease;
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, #0038ff, #0091ff);
+  color: #fff;
+  box-shadow: 0 24px 44px rgba(0, 56, 255, 0.25);
+}
+
+.btn-primary:hover {
+  transform: translateY(-4px) scale(1.01);
+  box-shadow: 0 32px 70px rgba(0, 56, 255, 0.3);
+  color: #fff;
+}
+
+.btn-ghost {
+  border-color: var(--surface-border);
+  color: var(--brand);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.btn-ghost:hover {
+  color: #fff;
+  border-color: transparent;
+  background: linear-gradient(120deg, rgba(0, 56, 255, 0.92), rgba(0, 145, 255, 0.92));
+  transform: translateY(-3px);
+}
+
+.btn-primary:active,
+.btn-ghost:active {
+  transform: translateY(0);
+}
+
+main {
+  padding-bottom: 6rem;
+}
+
+section {
+  padding: clamp(4.5rem, 6vw, 6.5rem) 0;
+}
+
+.hero {
+  padding-top: clamp(6rem, 9vw, 8rem);
+}
+
+.hero-inner {
+  display: grid;
+  gap: clamp(3rem, 6vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  align-items: center;
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 2;
+}
+
+.hero-copy::after {
+  content: '';
+  position: absolute;
+  inset: -18% -25% auto auto;
+  width: clamp(220px, 42vw, 320px);
+  height: clamp(220px, 42vw, 320px);
+  background: radial-gradient(circle at 30% 30%, rgba(0, 145, 255, 0.15), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(0, 56, 255, 0.22), transparent 70%);
+  filter: blur(28px);
+  opacity: 0.75;
+  z-index: -1;
+}
+
+.hero-media {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+  justify-items: stretch;
+  padding-bottom: 3.5rem;
+}
+
+.hero-visual {
+  position: relative;
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-xl);
+  max-width: 420px;
+  justify-self: center;
+  width: 100%;
+}
+
+.hero-visual img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.08);
+  transition: transform 12s ease;
+}
+
+.hero-media:hover .hero-visual img {
+  transform: scale(1.18);
+}
+
+.floating-card {
+  position: absolute;
+  bottom: -2rem;
+  right: 1.5rem;
+  min-width: 220px;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem 1.4rem;
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+}
+
+.floating-card strong {
+  font-size: 1.05rem;
+  color: var(--muted-strong);
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.floating-card span {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(0, 56, 255, 0.08);
+  border: 1px solid rgba(0, 56, 255, 0.18);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--brand);
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 6vw, 4.65rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+  margin: 1.75rem 0 1.35rem;
+  background: linear-gradient(120deg, var(--text), #0038ff, #0091ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero p {
+  max-width: 640px;
+  font-size: 1.15rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2.2rem;
+}
+
+.hero-annotation {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hero-annotation .icon {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(0, 56, 255, 0.1);
+  color: var(--brand);
+}
+
+.hero-panel {
+  position: relative;
+}
+
+.glass-card {
+  border-radius: var(--radius-xl);
+  padding: 2.4rem;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+}
+
+.glass-card h3 {
+  font-size: 1.4rem;
+  margin-bottom: 1.2rem;
+  color: var(--muted-strong);
+}
+
+.glass-card p {
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+}
+
+.checklist {
+  list-style: none;
+  display: grid;
+  gap: 0.95rem;
+}
+
+.checklist li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  color: var(--muted-strong);
+}
+
+.check-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(0, 56, 255, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--brand);
+  margin-top: 0.1rem;
+}
+
+.check-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.metrics-grid {
+  margin-top: 2.75rem;
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.metric {
+  padding: 1.25rem 1.4rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--surface-border);
+  background: var(--surface-strong);
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.8rem;
+  color: var(--brand);
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  margin-bottom: 3rem;
+}
+
+.section-heading h2 {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  letter-spacing: -0.02em;
+}
+
+.section-heading p {
+  max-width: 640px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.6rem;
+}
+
+.feature-card {
+  position: relative;
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(236, 242, 255, 0.92));
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1), border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.feature-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(0, 145, 255, 0.15), transparent 55%);
+  opacity: 0;
+  transition: var(--transition);
+}
+
+.feature-card:hover::after {
+  opacity: 1;
+}
+
+.feature-card:hover {
+  transform: translateY(-8px);
+  border-color: rgba(0, 56, 255, 0.25);
+  box-shadow: var(--shadow-md);
+}
+
+.feature-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: rgba(0, 56, 255, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--brand);
+  margin-bottom: 1.35rem;
+}
+
+.feature-icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.feature-card h3 {
+  font-size: 1.35rem;
+  margin-bottom: 0.8rem;
+}
+
+.feature-card ul {
+  margin-top: 1.1rem;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.feature-card ul li {
+  position: relative;
+  padding-left: 1.4rem;
+  line-height: 1.5;
+}
+
+.feature-card ul li::before {
+  content: '';
+  position: absolute;
+  top: 0.65em;
+  left: 0;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #0038ff, #7cd8ff);
+  box-shadow: 0 0 0 2px rgba(0, 56, 255, 0.12);
+}
+
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.8rem, 4vw, 2.6rem);
+  margin-top: clamp(2.5rem, 5vw, 3.2rem);
+}
+
+.portfolio-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  background: var(--bg-strong);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1), box-shadow 0.45s ease;
+  display: grid;
+}
+
+.portfolio-card img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  filter: saturate(1.1);
+}
+
+.portfolio-card-content {
+  padding: 1.8rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.portfolio-card:hover {
+  transform: translateY(-10px) scale(1.01);
+  box-shadow: var(--shadow-md);
+}
+
+.portfolio-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.portfolio-tags span {
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(0, 56, 255, 0.08);
+  border: 1px solid rgba(0, 56, 255, 0.18);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.scroll-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: rgba(0, 56, 255, 0.08);
+  border: 1px solid rgba(0, 56, 255, 0.16);
+  font-size: 0.85rem;
+  color: var(--brand);
+  margin-top: 1rem;
+}
+
+.scroll-note .icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 56, 255, 0.12);
+  color: var(--brand);
+}
+
+[data-animate] {
+  opacity: 0;
+  transform: translateY(50px);
+  transition: opacity 0.9s ease, transform 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-animate].in-view {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.split-section {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+}
+
+.split-card {
+  border-radius: var(--radius-lg);
+  padding: 2.25rem;
+  background: var(--bg-strong);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.service-callout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.75rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(0, 56, 255, 0.08), rgba(120, 162, 255, 0.12));
+  border: 1px solid rgba(0, 56, 255, 0.2);
+  color: var(--muted-strong);
+}
+
+.service-callout .callout-kicker {
+  font-weight: 700;
+  color: var(--brand);
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.service-callout .callout-kicker .icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(0, 56, 255, 0.12);
+  color: var(--brand);
+}
+
+.service-callout p {
+  margin: 0;
+}
+
+.section-alt {
+  position: relative;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(236, 242, 255, 0.95));
+}
+
+.section-alt::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 12% 18%, rgba(0, 56, 255, 0.1), transparent 55%),
+    radial-gradient(circle at 88% 20%, rgba(0, 145, 255, 0.12), transparent 52%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.section-alt .container {
+  position: relative;
+  z-index: 1;
+}
+
+.timeline {
+  border-left: 1px solid var(--surface-border);
+  padding-left: 1.5rem;
+  display: grid;
+  gap: 1.8rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  margin-top: 1.5rem;
+}
+
+.pricing-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+  background: var(--bg-strong);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.pricing-table th,
+.pricing-table td {
+  padding: 1.1rem 1.25rem;
+  text-align: left;
+  border-bottom: 1px solid var(--surface-border);
+  color: var(--muted-strong);
+}
+
+.pricing-table thead {
+  background: linear-gradient(135deg, rgba(0, 56, 255, 0.12), rgba(0, 145, 255, 0.16));
+  color: var(--brand-dark);
+}
+
+.pricing-table th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+
+.pricing-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.timeline-item h3 {
+  font-size: 1.2rem;
+  color: var(--brand);
+  margin-bottom: 0.35rem;
+}
+
+.timeline-item p {
+  font-size: 1rem;
+}
+
+.list-highlight {
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  color: var(--muted);
+}
+
+.list-highlight span {
+  color: var(--muted-strong);
+  font-weight: 600;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.contact-info {
+  border-radius: var(--radius-lg);
+  padding: 2.35rem;
+  background: var(--bg-strong);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.4rem;
+}
+
+.contact-info h3 {
+  font-size: 1.35rem;
+  color: var(--muted-strong);
+}
+
+.contact-info a {
+  color: var(--brand);
+}
+
+.contact-form {
+  border-radius: var(--radius-lg);
+  padding: 2.35rem;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.contact-form label {
+  font-weight: 600;
+  color: var(--muted-strong);
+  font-size: 0.95rem;
+}
+
+.contact-form input,
+.contact-form textarea,
+.contact-form select {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #ffffff;
+  color: var(--text);
+  font-size: 1rem;
+  transition: var(--transition);
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus,
+.contact-form select:focus {
+  outline: none;
+  border-color: rgba(0, 56, 255, 0.45);
+  box-shadow: 0 0 0 3px rgba(0, 56, 255, 0.12);
+}
+
+.contact-form textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.footer {
+  padding: 4.5rem 0 3rem;
+  border-top: 1px solid var(--surface-border);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.footer-grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.footer p {
+  font-size: 0.95rem;
+}
+
+.footer h4 {
+  font-size: 1.05rem;
+  margin-bottom: 1rem;
+  color: var(--muted-strong);
+}
+
+.footer-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.footer-links a:hover {
+  color: var(--brand);
+}
+
+.footer-bottom {
+  margin-top: 3rem;
+  border-top: 1px solid var(--surface-border);
+  padding-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.socials {
+  display: inline-flex;
+  gap: 0.9rem;
+}
+
+.socials a {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 56, 255, 0.08);
+  color: var(--brand);
+  border: 1px solid rgba(0, 56, 255, 0.18);
+}
+
+.socials a svg {
+  width: 18px;
+  height: 18px;
+}
+
+.socials a:hover {
+  background: rgba(0, 56, 255, 0.18);
+}
+
+.small-note {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.small-note .icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(0, 56, 255, 0.1);
+  color: var(--brand);
+  margin-right: 0.55rem;
+}
+
+.badge-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(0, 56, 255, 0.08);
+  border: 1px solid rgba(0, 56, 255, 0.18);
+  font-size: 0.85rem;
+  color: var(--muted-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.tagline {
+  font-size: 1.1rem;
+  color: var(--muted);
+  max-width: 520px;
+}
+
+.quote {
+  font-size: 1.05rem;
+  color: var(--muted);
+  border-left: 3px solid rgba(0, 56, 255, 0.35);
+  padding-left: 1rem;
+}
+
+@media (max-width: 1024px) {
+  .nav {
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 900px) {
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .nav-cta-desktop {
+    display: none;
+  }
+
+  .nav-links {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.6rem;
+    padding: 1.35rem;
+    background: var(--bg-strong);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition: var(--transition);
+    z-index: 20;
+  }
+
+  .nav-links.open {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .nav-links li,
+  .nav-links a {
+    width: 100%;
+  }
+
+  .nav-links a {
+    text-align: left;
+  }
+
+  .nav-links a:hover,
+  .nav-links a.active {
+    background: rgba(0, 56, 255, 0.1);
+  }
+
+  .nav-cta {
+    display: block;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero h1 {
+    font-size: clamp(2.5rem, 8vw, 3.35rem);
+  }
+
+  .floating-card {
+    position: static;
+    max-width: 320px;
+    width: 100%;
+    text-align: left;
+    margin-top: 1rem;
+  }
+
+  .hero-actions {
+    gap: 0.75rem;
+  }
+
+  .feature-grid {
+    gap: 1.2rem;
+  }
+
+  .contact-grid {
+    gap: 1.8rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .pricing-table {
+    min-width: 100%;
+  }
+
+  .pricing-table th,
+  .pricing-table td {
+    white-space: normal;
+  }
+}
+
+@media (max-width: 520px) {
+  .hero-inner {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-visual {
+    max-width: 100%;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/img/portfolio-radix.svg
+++ b/assets/img/portfolio-radix.svg
@@ -1,0 +1,20 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="radixGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b1f3a"/>
+      <stop offset="60%" stop-color="#1c4c80"/>
+      <stop offset="100%" stop-color="#2f7ad3"/>
+    </linearGradient>
+    <linearGradient id="radixAccent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8fe1ff" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#4ac1ff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#radixGradient)"/>
+  <path d="M160 640 L440 240 L640 520 L860 200 L1040 520" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M200 660 L1040 660" stroke="url(#radixAccent)" stroke-width="14" stroke-linecap="round"/>
+  <circle cx="860" cy="360" r="140" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="440" cy="360" r="120" fill="rgba(255,255,255,0.12)"/>
+  <rect x="280" y="520" width="200" height="90" rx="20" fill="rgba(12,66,120,0.8)"/>
+  <rect x="720" y="420" width="220" height="110" rx="24" fill="rgba(12,66,120,0.6)"/>
+</svg>

--- a/assets/img/portfolio-telecom.svg
+++ b/assets/img/portfolio-telecom.svg
@@ -1,0 +1,27 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="telecomGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f1020"/>
+      <stop offset="100%" stop-color="#1c2c60"/>
+    </linearGradient>
+    <radialGradient id="telecomGlow" cx="70%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#65f5ff" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#65f5ff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#telecomGradient)"/>
+  <rect x="200" y="200" width="800" height="360" rx="48" fill="rgba(25,45,110,0.75)" stroke="rgba(101,245,255,0.35)" stroke-width="6"/>
+  <circle cx="860" cy="300" r="140" fill="url(#telecomGlow)"/>
+  <g fill="none" stroke="#65f5ff" stroke-width="10" stroke-linecap="round">
+    <path d="M280 320 H920" opacity="0.35"/>
+    <path d="M280 380 H920" opacity="0.2"/>
+    <path d="M280 440 H920" opacity="0.15"/>
+  </g>
+  <g stroke="#65f5ff" stroke-width="6" stroke-linecap="round">
+    <path d="M280 540 C420 520 520 620 660 600" opacity="0.5"/>
+    <path d="M660 600 C780 580 880 640 960 620" opacity="0.35"/>
+  </g>
+  <circle cx="320" cy="540" r="18" fill="#65f5ff"/>
+  <circle cx="520" cy="620" r="14" fill="#65f5ff" opacity="0.75"/>
+  <circle cx="780" cy="610" r="12" fill="#65f5ff" opacity="0.6"/>
+</svg>

--- a/assets/img/portfolio-vibrant.svg
+++ b/assets/img/portfolio-vibrant.svg
@@ -1,0 +1,18 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="vibrantGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f8a1ff"/>
+      <stop offset="50%" stop-color="#7ad7ff"/>
+      <stop offset="100%" stop-color="#3ec7a2"/>
+    </linearGradient>
+    <radialGradient id="vibrantHighlight" cx="35%" cy="30%" r="65%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#vibrantGradient)"/>
+  <circle cx="320" cy="220" r="180" fill="url(#vibrantHighlight)"/>
+  <circle cx="920" cy="620" r="260" fill="rgba(255,255,255,0.15)"/>
+  <path d="M240 560 C360 440 540 480 640 360 C760 220 960 280 1060 160" stroke="rgba(255,255,255,0.4)" stroke-width="22" stroke-linecap="round" fill="none"/>
+  <path d="M180 620 C340 540 520 620 700 500" stroke="rgba(255,255,255,0.25)" stroke-width="18" stroke-linecap="round" fill="none"/>
+</svg>

--- a/assets/img/walker-media-logo.svg
+++ b/assets/img/walker-media-logo.svg
@@ -1,0 +1,19 @@
+<svg width="360" height="160" viewBox="0 0 360 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Walker Media logo</title>
+  <desc id="desc">Walker Media wordmark beside a rocket icon enclosed in a rounded rectangle.</desc>
+  <rect x="6" y="6" width="348" height="148" rx="20" fill="#ffffff" stroke="#0038ff" stroke-width="12" />
+  <g fill="#0038ff" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" letter-spacing="4">
+    <text font-size="44" x="36" y="84">WALKER</text>
+    <text font-size="44" x="36" y="128">MEDIA</text>
+  </g>
+  <g transform="translate(236 28)" fill="none" stroke="#0038ff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="0" y="0" width="112" height="112" rx="20" />
+    <path d="M56 16c-18 14-24 34-22 46l22-10 22 10c2-12-4-32-22-46z" fill="#ffffff" />
+    <circle cx="56" cy="44" r="10" />
+    <path d="M56 52v26" />
+    <path d="M40 86l16-10 16 10" />
+    <path d="M36 62l-8 22 16-10" />
+    <path d="M76 62l8 22-16-10" />
+    <path d="M56 90v18" />
+  </g>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,73 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const yearElement = document.getElementById('year');
+  if (yearElement) {
+    yearElement.textContent = new Date().getFullYear();
+  }
+
+  const animatedSections = document.querySelectorAll('[data-animate]');
+
+  const reveal = (section) => {
+    section.classList.add('in-view');
+  };
+
+  if (animatedSections.length) {
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(
+        (entries, obs) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              reveal(entry.target);
+              obs.unobserve(entry.target);
+            }
+          });
+        },
+        { rootMargin: '0px 0px -10% 0px', threshold: 0.2 }
+      );
+
+      animatedSections.forEach((section) => observer.observe(section));
+    } else {
+      animatedSections.forEach(reveal);
+    }
+  }
+
+  const menuToggle = document.querySelector('.menu-toggle');
+  const navLinks = document.getElementById('primary-navigation');
+  if (menuToggle && navLinks) {
+    const closeMenu = () => {
+      navLinks.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('nav-open');
+    };
+
+    menuToggle.addEventListener('click', () => {
+      const isOpen = navLinks.classList.toggle('open');
+      menuToggle.setAttribute('aria-expanded', isOpen.toString());
+      document.body.classList.toggle('nav-open', isOpen);
+    });
+
+    navLinks.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        if (navLinks.classList.contains('open')) {
+          closeMenu();
+        }
+      });
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth > 900) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && navLinks.classList.contains('open')) {
+        closeMenu();
+        menuToggle.focus();
+      }
+    });
+  }
+
+  if (window.feather && typeof window.feather.replace === 'function') {
+    window.feather.replace();
+  }
+});

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact Walker Media | Start Your Next Web, SEO, or AI Project</title>
+  <meta name="description" content="Connect with Walker Media to launch custom web design, branding, SEO, and AI automation engagements. Schedule a discovery call or request a proposal.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <nav class="nav">
+        <a class="brand" href="index.html">
+          <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+          <span class="brand-name">Walker Media</span>
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label" aria-hidden="true">Menu</span>
+        </button>
+        <ul class="nav-links" id="primary-navigation">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Web &amp; Product</a></li>
+          <li><a href="ai-services.html">AI Services</a></li>
+          <li><a class="active" href="contact.html">Contact</a></li>
+          <li class="nav-cta"><a class="btn btn-primary" href="contact.html">Book a Discovery Call</a></li>
+        </ul>
+        <a class="btn btn-ghost nav-cta-desktop" href="contact.html">Book a Discovery Call</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-inner">
+        <div class="hero-copy" data-animate>
+          <span class="eyebrow">Let’s build</span>
+          <h1>Ready for a website, brand, or AI rollout that outranks and outperforms?</h1>
+          <p>Tell the Walker Media team about your brand, product, or operational challenges. The studio partners with teams nationwide to launch high-impact design, development, SEO, and AI initiatives.</p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="mailto:zac@walkermediaco.com">Email Walker Media</a>
+            <div class="hero-annotation">
+              <span class="icon" aria-hidden="true"><i data-feather="calendar"></i></span>
+              <div>Discovery calls typically available within 3 business days.</div>
+            </div>
+          </div>
+        </div>
+        <div class="hero-panel" data-animate>
+          <div class="glass-card">
+            <h3>What to include</h3>
+            <ul class="checklist">
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Your company, product, or idea.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Current challenges and success metrics.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Desired timeline, budget, or constraints.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container contact-grid">
+        <div class="contact-info" data-animate>
+          <h3>Direct contact</h3>
+          <p><a href="mailto:zac@walkermediaco.com">zac@walkermediaco.com</a></p>
+          <p>Remote-first studio partnering with teams across the U.S.</p>
+          <div>
+            <h4 style="color: var(--muted-strong);">Project fit</h4>
+            <ul class="list-highlight">
+              <li><span>Ideal budget:</span> $10k–$75k for launch engagements</li>
+              <li><span>Timeline:</span> 6–12 weeks for brand & web, 2–6 weeks for AI sprints</li>
+              <li><span>Availability:</span> Limited Q3 spots remaining</li>
+            </ul>
+          </div>
+        </div>
+        <form class="contact-form" action="https://formsubmit.co/zac@walkermediaco.com" method="POST" data-animate>
+          <input type="hidden" name="_subject" value="New project inquiry from walkermedia.co">
+          <input type="hidden" name="_captcha" value="false">
+          <div>
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" placeholder="Your full name" required>
+          </div>
+          <div>
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" placeholder="you@company.com" required>
+          </div>
+          <div>
+            <label for="company">Company</label>
+            <input type="text" id="company" name="company" placeholder="Company or organization">
+          </div>
+          <div>
+            <label for="services">What are you interested in?</label>
+            <select id="services" name="services">
+              <option value="brand">Brand design system</option>
+              <option value="web">Website or product build</option>
+              <option value="seo">SEO & growth engagement</option>
+              <option value="ai">AI implementation</option>
+              <option value="other">Other / unsure</option>
+            </select>
+          </div>
+          <div>
+            <label for="timeline">Timeline</label>
+            <select id="timeline" name="timeline">
+              <option value="immediate">Immediately</option>
+              <option value="1-3">1-3 months</option>
+              <option value="3-6">3-6 months</option>
+              <option value="flexible">Flexible</option>
+            </select>
+          </div>
+          <div>
+            <label for="message">Project details</label>
+            <textarea id="message" name="message" placeholder="Share goals, deliverables, or links."></textarea>
+          </div>
+          <button type="submit" class="btn btn-primary" style="width: fit-content;">Send message</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html">
+            <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+            <span class="brand-name">Walker Media</span>
+          </a>
+          <p>World-class branding, web, and AI solutions crafted with agency-level polish and the agility of a boutique partner.</p>
+        </div>
+        <div>
+          <h4>Studio</h4>
+          <p>Remote-first, partnering nationwide<br>Selective engagements focused on measurable outcomes.</p>
+        </div>
+        <div class="footer-links">
+          <h4>Explore</h4>
+          <p><a href="about.html">About</a></p>
+          <p><a href="services.html">Web &amp; Product</a></p>
+          <p><a href="ai-services.html">AI Services</a></p>
+          <p><a href="contact.html">Contact</a></p>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <small>© <span id="year"></span> Walker Media. All rights reserved.</small>
+        <div class="socials">
+          <a href="https://www.linkedin.com" aria-label="LinkedIn"><i data-feather="linkedin"></i></a>
+          <a href="mailto:zac@walkermediaco.com" aria-label="Email"><i data-feather="mail"></i></a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <script src="https://unpkg.com/feather-icons" defer></script>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Walker Media | Custom Web Design, Branding & AI Automation</title>
+  <meta name="description" content="Walker Media is a senior web design and AI automation studio delivering custom branding, high-converting websites, SEO, and intelligent workflows for growth-focused teams.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <nav class="nav">
+        <a class="brand" href="index.html">
+          <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+          <span class="brand-name">Walker Media</span>
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label" aria-hidden="true">Menu</span>
+        </button>
+        <ul class="nav-links" id="primary-navigation">
+          <li><a class="active" href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Web &amp; Product</a></li>
+          <li><a href="ai-services.html">AI Services</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li class="nav-cta"><a class="btn btn-primary" href="contact.html">Book a Discovery Call</a></li>
+        </ul>
+        <a class="btn btn-ghost nav-cta-desktop" href="contact.html">Book a Discovery Call</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-inner">
+        <div class="hero-copy" data-animate>
+          <span class="eyebrow">Custom brands • Conversion-led websites • AI automation</span>
+          <h1>Custom web design, branding, and AI automations engineered to scale revenue.</h1>
+          <p>Walker Media is a senior web design and AI automation studio with 15+ years building search-optimized websites, cohesive brand systems, and intelligent workflows that remove repetitive work for marketing and sales teams.</p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="services.html">Explore Web &amp; Product</a>
+            <a class="btn btn-ghost" href="ai-services.html">See AI Services</a>
+            <div class="hero-annotation">
+              <span class="icon" aria-hidden="true"><i data-feather="star"></i></span>
+              <div>High-touch partnership delivering launches in as little as 6 weeks.</div>
+            </div>
+          </div>
+          <div class="scroll-note">
+            <span class="icon" aria-hidden="true"><i data-feather="chevron-down"></i></span>
+            <span>Scroll to see recent wins and our service approach.</span>
+          </div>
+          <div class="metrics-grid">
+            <div class="metric">
+              <strong>15+ yrs</strong>
+              Enterprise-grade design, development, SEO, and AI implementation expertise.
+            </div>
+            <div class="metric">
+              <strong>300%+</strong>
+              Average lift in qualified leads after launch of conversion-focused sites.
+            </div>
+            <div class="metric">
+              <strong>120 hrs</strong>
+              Saved quarterly with tailored AI agents and automated knowledge hubs.
+            </div>
+          </div>
+        </div>
+        <div class="hero-media" data-animate>
+          <div class="hero-visual">
+            <img src="https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&w=900&q=80" alt="Designers collaborating over interface concepts displayed on laptops in a modern studio.">
+          </div>
+          <div class="floating-card">
+            <strong>AI-first launch partner</strong>
+            <span>Design, build, and automate in orchestrated weekly sprints.</span>
+          </div>
+          <div class="glass-card">
+            <h3>Roadmap to measurable growth</h3>
+            <p>Every engagement follows an orchestrated blueprint focused on revenue, retention, and operational efficiency.</p>
+            <ul class="checklist">
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Immersive discovery workshops to uncover friction and opportunity.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Design systems and storytelling built to convert across every touchpoint.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Custom development tuned for performance, accessibility, and speed.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>AI agents deployed to automate workflows, reporting, and customer care.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Services</span>
+          <h2>End-to-end digital solutions designed for authority, speed, and measurable growth.</h2>
+          <p>Partner with a senior web design expert who blends brand strategy, product-level UX, development, SEO, and AI into one cohesive roadmap.</p>
+        </div>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true"><i data-feather="pen-tool"></i></div>
+            <h3>Brand Design Systems</h3>
+            <p>Develop a memorable visual and verbal identity with conversion-ready messaging, typography, and component libraries that scale with your business.</p>
+            <ul>
+              <li>Positioning, voice, and narrative frameworks</li>
+              <li>Complete visual systems & motion language</li>
+              <li>Guidelines and asset kits for every channel</li>
+            </ul>
+          </div>
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true"><i data-feather="code"></i></div>
+            <h3>Custom Web Development</h3>
+            <p>Launch responsive, conversion-focused experiences powered by modern stacks, accessibility-first best practices, and meticulous QA.</p>
+            <ul>
+              <li>Component-driven front-ends & headless builds</li>
+              <li>Performance, accessibility & SEO baked in</li>
+              <li>Analytics-ready launch plans and iterations</li>
+            </ul>
+          </div>
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true"><i data-feather="trending-up"></i></div>
+            <h3>SEO & Growth</h3>
+            <p>Extend your reach with full-funnel SEO strategies, editorial systems, and experimentation that translate to measurable leads.</p>
+            <ul>
+              <li>Technical audits & content architectures</li>
+              <li>Growth experiments across paid & organic</li>
+              <li>Dashboarding and executive-ready reporting</li>
+            </ul>
+          </div>
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true"><i data-feather="cpu"></i></div>
+            <h3>AI Implementation</h3>
+            <p>Empower teams with AI copilots that automate workflows, answer customers in real time, and synthesize knowledge for faster decisions.</p>
+            <ul>
+              <li>Process mapping & automation design</li>
+              <li>Custom-trained agents embedded into stacks</li>
+              <li>Governance, training & optimization support</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Previous Work</span>
+          <h2>Case studies proving that brand, product, and AI can move in lockstep.</h2>
+          <p>Explore recent website redesigns, brand launches, and automation engagements that pair premium aesthetics with measurable KPIs.</p>
+        </div>
+        <div class="portfolio-grid">
+          <article class="portfolio-card">
+            <img src="assets/img/portfolio-vibrant.svg" alt="Abstract gradient artwork representing the Vibrant Living at Home brand system.">
+            <div class="portfolio-card-content">
+              <h3>Vibrant Living at Home</h3>
+              <p>Crafted a warm, trustworthy brand system, a custom website with SEO-driven blog engine, and automated nurture flows for the in-home care team.</p>
+              <div class="portfolio-tags">
+                <span>Brand</span>
+                <span>Web</span>
+                <span>Automation</span>
+              </div>
+            </div>
+          </article>
+          <article class="portfolio-card">
+            <img src="assets/img/portfolio-radix.svg" alt="Geometric blueprint illustration inspired by the Radix Law digital experience.">
+            <div class="portfolio-card-content">
+              <h3>Radix Law</h3>
+              <p>Designed and built a bespoke Scottsdale law firm site with localized SEO architecture, intake automations, and crystal clear service positioning.</p>
+              <div class="portfolio-tags">
+                <span>Web</span>
+                <span>SEO</span>
+                <span>Automation</span>
+              </div>
+            </div>
+          </article>
+          <article class="portfolio-card">
+            <img src="assets/img/portfolio-telecom.svg" alt="Neon-inspired illustration showcasing the Telecom Advisors Group digital transformation.">
+            <div class="portfolio-card-content">
+              <h3>Telecom Advisors Group</h3>
+              <p>Reimagined the national consultancy with a future-proof identity, modular CMS, and AI-assisted proposal workflows to speed up enterprise deals.</p>
+              <div class="portfolio-tags">
+                <span>Brand</span>
+                <span>Web</span>
+                <span>AI</span>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Collaborate</span>
+          <h2>Your next flagship launch starts with a data-backed conversation.</h2>
+          <p class="tagline">Walker Media is built for founders and marketing leaders who crave the craft of world-class digital products paired with analytics, SEO, and AI that keep growth compounding.</p>
+        </div>
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <h3>What you can expect</h3>
+            <ul class="list-highlight">
+              <li><span>Discovery intensives:</span> Uncover buyer journeys, keyword opportunities, and automation gaps.</li>
+              <li><span>Transparent roadmaps:</span> Weekly progress, milestone clarity, analytics check-ins, and collaborative reviews.</li>
+              <li><span>Launch & beyond:</span> Optimization sprints, AI enablement, and SEO retainers keep your investment compounding.</li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <h3>Ideal partners</h3>
+            <p class="quote">“We’re ready for a site and AI-enhanced operations that communicate our value, rank on search, and remove manual busywork for our team.”</p>
+            <p class="small-note">If that sounds like you, let’s build something remarkable, measurable, and automated together.</p>
+            <a class="btn btn-primary" href="contact.html" style="margin-top:1.75rem; width:fit-content;">Schedule a strategy call</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html">
+            <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+            <span class="brand-name">Walker Media</span>
+          </a>
+          <p>World-class branding, web, and AI solutions crafted with agency-level polish and the agility of a boutique partner.</p>
+        </div>
+        <div>
+          <h4>Studio</h4>
+          <p>Remote-first, partnering nationwide<br>Selective engagements focused on measurable outcomes.</p>
+        </div>
+        <div class="footer-links">
+          <h4>Explore</h4>
+          <p><a href="about.html">About</a></p>
+          <p><a href="services.html">Web &amp; Product</a></p>
+          <p><a href="ai-services.html">AI Services</a></p>
+          <p><a href="contact.html">Contact</a></p>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <small>© <span id="year"></span> Walker Media. All rights reserved.</small>
+        <div class="socials">
+          <a href="https://www.linkedin.com" aria-label="LinkedIn"><i data-feather="linkedin"></i></a>
+          <a href="mailto:zac@walkermediaco.com" aria-label="Email"><i data-feather="mail"></i></a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <script src="https://unpkg.com/feather-icons" defer></script>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Web &amp; Product Services | Walker Media Websites &amp; SEO</title>
+  <meta name="description" content="Explore Walker Media’s web and product services—from research and UX architecture to full-stack development, optimization, and recent case studies built for measurable growth.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <nav class="nav">
+        <a class="brand" href="index.html">
+          <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+          <span class="brand-name">Walker Media</span>
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label" aria-hidden="true">Menu</span>
+        </button>
+        <ul class="nav-links" id="primary-navigation">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a class="active" href="services.html">Web &amp; Product</a></li>
+          <li><a href="ai-services.html">AI Services</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li class="nav-cta"><a class="btn btn-primary" href="contact.html">Book a Discovery Call</a></li>
+        </ul>
+        <a class="btn btn-ghost nav-cta-desktop" href="contact.html">Book a Discovery Call</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-inner">
+        <div class="hero-copy" data-animate>
+          <span class="eyebrow">Web &amp; Product</span>
+          <h1>High-converting websites and digital products engineered for performance.</h1>
+          <p>Walker Media architects search-optimized websites, conversion-led digital experiences, and maintainable CMS builds that bring your positioning to life and turn traffic into qualified demand.</p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="contact.html">Start your project</a>
+            <a class="btn btn-ghost" href="ai-services.html">Need AI services?</a>
+            <div class="hero-annotation">
+              <span class="icon" aria-hidden="true"><i data-feather="zap"></i></span>
+              <div>6–12 week launch timelines with SEO, analytics, and content baked in.</div>
+            </div>
+          </div>
+        </div>
+        <div class="hero-panel" data-animate>
+          <div class="glass-card">
+            <h3>What every engagement includes</h3>
+            <ul class="checklist">
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Audience, keyword, and funnel discovery to inform UX and copy.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Design systems, component libraries, and motion specs ready for scale.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Performance-first development with documentation and training.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Strategy to Ship</span>
+          <h2>Everything required to launch a site that ranks, converts, and tells your story.</h2>
+          <p>Each build blends research, UX, design, development, and SEO so your team gets a flagship experience that is easy to manage and impossible to ignore.</p>
+        </div>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true"><i data-feather="compass"></i></div>
+            <h3>Research &amp; Architecture</h3>
+            <p>Clarify goals and user journeys, map SEO-informed site structures, and define content requirements before design begins.</p>
+            <ul>
+              <li>Stakeholder and audience discovery</li>
+              <li>Information architecture &amp; funnel mapping</li>
+              <li>Wireframes, prototypes, and testing loops</li>
+            </ul>
+          </div>
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true"><i data-feather="feather"></i></div>
+            <h3>Interface &amp; Content Design</h3>
+            <p>Craft immersive visuals, copy, and interactions that showcase your product value while guiding visitors toward action.</p>
+            <ul>
+              <li>Responsive design systems &amp; motion specs</li>
+              <li>Conversion and SEO-led copywriting</li>
+              <li>Photography &amp; media art direction</li>
+            </ul>
+          </div>
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true"><i data-feather="tool"></i></div>
+            <h3>Full-stack Development</h3>
+            <p>Develop fast, accessible sites with modern tooling, CMS integrations, and deployment workflows your team can own.</p>
+            <ul>
+              <li>Component-driven builds in modern stacks</li>
+              <li>CMS setup, migrations, and author training</li>
+              <li>Performance, accessibility, and QA sweeps</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Optimize &amp; Grow</span>
+          <h2>Stay ahead with continuous improvement and data-backed experimentation.</h2>
+          <p>From technical SEO to conversion optimization, Walker Media keeps your launch evolving alongside market shifts and search trends.</p>
+        </div>
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <h3>Post-launch support</h3>
+            <ul class="list-highlight">
+              <li><span>Measurement dashboards:</span> Track rankings, conversions, and engagement with executive-ready reporting.</li>
+              <li><span>Experimentation:</span> Run A/B tests, landing page iterations, and CRO experiments that maximize ROI.</li>
+              <li><span>Content operations:</span> Editorial calendars, on-page SEO, and blog systems that keep fresh traffic flowing.</li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <h3>Team enablement</h3>
+            <ul class="checklist">
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Training sessions for marketers, content teams, and internal devs.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Documentation and playbooks for updates, launches, and QA.</li>
+              <li><span class="check-icon" aria-hidden="true"><i data-feather="check"></i></span>Optional retainers covering SEO, analytics, and feature enhancements.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section data-animate>
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Featured Projects</span>
+          <h2>Recent web and product launches crafted by Walker Media.</h2>
+          <p>Real client work that blends brand storytelling, technical SEO, and performance-first development.</p>
+        </div>
+        <div class="portfolio-grid">
+          <article class="portfolio-card">
+            <img src="assets/img/portfolio-vibrant.svg" alt="Abstract gradient artwork representing the Vibrant Living at Home brand system.">
+            <div class="portfolio-card-content">
+              <h3>Vibrant Living at Home</h3>
+              <p>Brand system, custom website, publishing workflow, and automated nurture emails for an in-home care provider expanding nationwide.</p>
+              <div class="portfolio-tags">
+                <span>Brand</span>
+                <span>Web</span>
+                <span>Automation</span>
+              </div>
+            </div>
+          </article>
+          <article class="portfolio-card">
+            <img src="assets/img/portfolio-radix.svg" alt="Geometric blueprint illustration inspired by the Radix Law digital experience.">
+            <div class="portfolio-card-content">
+              <h3>Radix Law</h3>
+              <p>Law firm site built from the ground up with localized SEO architecture, streamlined intake forms, and automated lead routing.</p>
+              <div class="portfolio-tags">
+                <span>Web</span>
+                <span>SEO</span>
+                <span>Automation</span>
+              </div>
+            </div>
+          </article>
+          <article class="portfolio-card">
+            <img src="assets/img/portfolio-telecom.svg" alt="Neon-inspired illustration showcasing the Telecom Advisors Group digital transformation.">
+            <div class="portfolio-card-content">
+              <h3>Telecom Advisors Group</h3>
+              <p>Future-proof identity, modular CMS, and AI-assisted proposal workflows powering a national telecommunications consultancy.</p>
+              <div class="portfolio-tags">
+                <span>Brand</span>
+                <span>Web</span>
+                <span>AI</span>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt" data-animate>
+      <div class="container">
+        <div class="split-section">
+          <div class="split-card" data-animate>
+            <h3>Process overview</h3>
+            <ul class="list-highlight">
+              <li><span>Discovery intensives:</span> Collaborative workshops uncover positioning, audience intent, and success metrics.</li>
+              <li><span>Design &amp; build sprints:</span> Weekly milestones keep strategy, creative, and development moving in sync.</li>
+              <li><span>Launch &amp; optimization:</span> QA, analytics setup, and ongoing iterations ensure the site keeps driving growth.</li>
+            </ul>
+          </div>
+          <div class="split-card" data-animate>
+            <h3>Ready to collaborate?</h3>
+            <p class="quote">“We’re ready for a flagship website that feels premium, performs brilliantly on mobile, and converts leads around the clock.”</p>
+            <p class="small-note">If that sounds like you, let’s map the roadmap together and turn your next launch into a growth engine.</p>
+            <a class="btn btn-primary" href="contact.html" style="margin-top:1.75rem; width:fit-content;">Book a discovery call</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html">
+            <img src="assets/img/walker-media-logo.svg" alt="Walker Media logo" class="brand-logo">
+            <span class="brand-name">Walker Media</span>
+          </a>
+          <p>World-class branding, web, and AI solutions crafted with agency-level polish and the agility of a boutique partner.</p>
+        </div>
+        <div>
+          <h4>Studio</h4>
+          <p>Remote-first, partnering nationwide<br>Selective engagements focused on measurable outcomes.</p>
+        </div>
+        <div class="footer-links">
+          <h4>Explore</h4>
+          <p><a href="about.html">About</a></p>
+          <p><a href="services.html">Web &amp; Product</a></p>
+          <p><a href="ai-services.html">AI Services</a></p>
+          <p><a href="contact.html">Contact</a></p>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <small>© <span id="year"></span> Walker Media. All rights reserved.</small>
+        <div class="socials">
+          <a href="https://www.linkedin.com" aria-label="LinkedIn"><i data-feather="linkedin"></i></a>
+          <a href="mailto:zac@walkermediaco.com" aria-label="Email"><i data-feather="mail"></i></a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <script src="https://unpkg.com/feather-icons" defer></script>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- swap emoji and text glyphs for Feather icons across every page and update the shared script to initialise them
- remove the home-page testimonials while tightening copy to highlight Walker Media as the team partner instead of Zac individually
- add locally hosted case-study illustrations and reuse them on services and home to prevent broken portfolio imagery

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e4911a03c8832ab07138a24e237c39